### PR TITLE
add mt7612u support

### DIFF
--- a/con_usb.c
+++ b/con_usb.c
@@ -46,6 +46,10 @@ static const struct dev_id {
 } devs[] = {
 	{0x148f, 0x7610},	/* Default ID of MT7610U */
 	{0x148f, 0x761a},	/* TP-Link T2U dongle */
+	/* mt7612 */
+	{0x0846, 0x9053}, /* NetGear, Inc. A6210 */
+	{0x148f, 0x7612},	/* Default ID of MT7612U */
+	{0x0e8d, 0x7612}, /* MediaTek Inc. MT7612U 802.11a/b/g/n/ac Wireless Adapter */
 };
 
 /* MediaTek specific (vendor) USB device commands */

--- a/mt7610.c
+++ b/mt7610.c
@@ -496,3 +496,4 @@ static int mt7610_eep_parse(struct main_ctx *mc)
 }
 
 CHIP(MT7610, 0x7610, mt7610_eep_parse);
+CHIP(MT7612, 0x7612, mt7610_eep_parse);


### PR DESCRIPTION
This is pretty generic, but it seems to work and provide sane looking output.  Example:
```
usbcon: EEPROM overlap detected at 0x0400
[EEPROM identification]
  ChipID        : 7612h
  Version       : 0.0
  Chip          : MT7612

[Device identification]
  MacAddr       : 28:80:88:df:68:1e
  PCIDevID      : 7662h
  PCIVenID      : 14C3h
  PCISubsysDevID: 7662h
  PCISubsysVenID: 14C3h
  USB Vendor ID : 0846h
  USB Product ID: 9053h

[ASIC data]
  CMB aux option: D837h
  XTAL opt???   : 409Dh

[NIC configuration]
  Cfg0          : FF22h
    RxPath      : 2
    TxPath      : 2
    PA 2GHz     : Internal
    PA 5GHz     : Internal
    PA current  : 8 ma
  Cfg1          : 208Ch
    RF Ctrl     : Driver
    Ext. TxALC  : Disable
    LNA 2GHz    : External
    LNA 5GHz    : External
    CardBus Acc.: Enable
    40MHz 2G SB : Disable
    40MHz 5G SB : Disable
    WPS button  : Enable
    40MHz 2GHz  : Enable
    40MHz 5GHz  : Enable
    Ant. divers.: No diversity
    Int. TxALC  : True
    Coexistance : False
    DAC test    : False
  Cfg2          : D7FFh
    RxStream    : 15
    TxStream    : 15
    CoexAnt     : True
    XtalOpt     : 3
    RxTempComp. : Enable
    CalibInFlash: True

[Misc params]
  FreqOffset    : A8h
  TempOffset    : -1

[Country region code]
  2GHz country  : FFh (<none>)
  5GHz country  : FFh (<none>)

[External LNA gain]
  2GHz (1-14)   : 8Dh (141 dB)
  5GHz (36-64)  : 89h (137 dB)
  5GHz (100-128): 88h (136 dB)
  5GHz (132-165): 87h (135 dB)
  5GHz mid chan : FFh (100, default)
  5GHz higt chan: FFh (155, default)

[BBP RSSI offsets]
  2GHz Offset0  : 00h (0 dB)
  2GHz Offset1  : 00h (0 dB)
  5GHz Offset0  : 00h (0 dB)
  5GHz Offset1  : 00h (0 dB)

[Tx power target]
  2GHz (20MHz)  : FFh (16.0 dBm, default)
  5GHz (20MHz)  : FFh (16.0 dBm, default)

[Tx power delta]
  2GHz 20/40MHz : 00h (0.0 dBm, disabled)
  5GHz 20/40MHz : 00h (0.0 dBm, disabled)
  5GHz 20/80MHz : FFh (0.0 dBm, default)

[Per channel power table]
  Subband: 2.4 GHz
  Channel:     1    2    3    4    5    6    7    8    9   10   11   12   13   14
  Raw    :   00h  00h  00h  B4h  7Fh  1Bh  1Eh  C4h  C5h  C5h  7Fh  11h  1Eh  C2h
  Pwr,dBm:   2.5  2.5  2.5  2.5  2.5 13.5 15.0  2.5  2.5  2.5  2.5  8.5 15.0  2.5
  Subband: 5 GHz (low)
  Channel:    36   38   40   44   46   48   52   54   56   60   62   64
  Raw    :   1Eh  C0h  C1h  7Ch  1Ah  1Eh  C1h  C3h  00h  00h  1Eh  C2h
  Pwr,dBm:  15.0  2.5  2.5  2.5 13.0 15.0  2.5  2.5  2.5  2.5 15.0  2.5
  Subband: 5 GHz (middle)
  Channel:   100  102  104  108  110  112  116  118  120  124  126  128  132  134  136  140
  Raw    :   C2h  84h  06h  1Eh  C5h  C5h  84h  06h  1Eh  C4h  C4h  82h  0Eh  1Eh  C4h  C5h
  Pwr,dBm:   2.5  2.5  3.0 15.0  2.5  2.5  2.5  3.0 15.0  2.5  2.5  2.5  7.0 15.0  2.5  2.5
  Subband: 5 GHz (hight)
  Channel:   149  151  153  157  159  161  165  167  169  171  173
  Raw    :   7Dh  18h  1Eh  C4h  C2h  7Bh  1Eh  1Eh  C5h  C5h  00h
  Pwr,dBm:   2.5 12.0 15.0  2.5  2.5  2.5 15.0 15.0  2.5  2.5  2.5

[Per rate power table]
                  .---------- Raw --------..--------- Power, dBm --------.
                  | 2.4GHz|   5GHz|   STBC||   2.4GHz|     5GHz|     STBC|
  CCK 1M/2M       :    FFh                       -0.5
  CCK 5.5M/11M    :    FFh                       -0.5
  OFDM 6M/9M      :    FFh     08h               -0.5       4.0
  OFDM 12M/18M    :    FFh     20h               -0.5     -16.0
  OFDM 24M/36M    :    FFh     04h               -0.5       2.0
  OFDM 48M/54M    :    FFh     2Ah               -0.5     -11.0
  HT/VHT MCS 0/1  :    FFh     90h     FFh       -0.5       8.0      -0.5
  HT/VHT MCS 2/3  :    FFh     00h     FFh       -0.5       0.0      -0.5
  HT/VHT MCS 4/5  :    FFh     00h     FFh       -0.5       0.0      -0.5
  HT/VHT MCS 6/7  :    FFh     24h     FFh       -0.5     -14.0      -0.5
  VHT MCS 8/9     :            D0h                          8.0

[TSSI temperature compensation]
  Tx AGC step   : 2.0 dBm
  5GHz boundary : 0 (channel)
  5GHz group 1  : {  -2   -2   -2   -2   -2   -2   -2   -1  -92   +9   -2   -2   -2   -2   -2}
  5GHz group 2  : {  -2   -2  -55  +14  -60 +115   +6   -1  -25  +60  +47  -81   +0  +37   +7}
```